### PR TITLE
fix: correctly process optional BOM for section labels at file start

### DIFF
--- a/configs/configs_mapped/parserutils/inireader/inireader.go
+++ b/configs/configs_mapped/parserutils/inireader/inireader.go
@@ -286,7 +286,7 @@ var regexLetter *regexp.Regexp
 func init() {
 	InitRegexExpression(&regexNumber, `^[0-9\-]+(?:\.)?([0-9\-]*)(?:E[-0-9]+)?$`)
 	InitRegexExpression(&regexComment, `;(.*)`)
-	InitRegexExpression(&regexSection, `^\[.*\]`)
+	InitRegexExpression(&regexSection, `^\x{FEFF}?\[.*\]`)
 	InitRegexExpression(&regexLetter, `[a-zA-Z]`)
 	// param or commented out param
 	InitRegexExpression(&regexParam, `(;%|^)[ 	]*([a-zA-Z_][a-zA-Z_0-9]+)\s=\s([a-zA-Z_, 0-9-.\/\\]+)`)


### PR DESCRIPTION
### Motivation

Processing of some INIs may fail because a BOM is present at the start of the file, which the section regex fails for.

### Solution

Adjust section regex to allow for an optional `U+FEFF` BOM character before the section name.