### PR TITLE
refactor: use xml decoder to correctly process PARA as newlines

### DIFF
--- a/configs/configs_mapped/freelancer_mapped/infocard_mapped/infocard/xml.go
+++ b/configs/configs_mapped/freelancer_mapped/infocard_mapped/infocard/xml.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"io"
+	"strings"
 )
 
 func (i *Infocard) XmlToText() ([]string, error) {
@@ -11,7 +12,8 @@ func (i *Infocard) XmlToText() ([]string, error) {
 }
 
 func XmlToText(raw string) ([]string, error) {
-	decoder := xml.NewDecoder(bytes.NewBufferString(raw))
+	prepared := strings.ReplaceAll(string(raw), `<?xml version="1.0" encoding="UTF-16"?>`, "")
+	decoder := xml.NewDecoder(bytes.NewBufferString(prepared))
 
 	lines := make([]string, 0)
 	line := ""

--- a/configs/configs_mapped/freelancer_mapped/infocard_mapped/infocard/xml.go
+++ b/configs/configs_mapped/freelancer_mapped/infocard_mapped/infocard/xml.go
@@ -16,7 +16,7 @@ func XmlToText(raw string) ([]string, error) {
 	decoder := xml.NewDecoder(bytes.NewBufferString(prepared))
 
 	lines := make([]string, 0)
-	line := ""
+	var sb strings.Builder
 	for {
 		token, err := decoder.Token()
 		if err != nil {
@@ -30,11 +30,11 @@ func XmlToText(raw string) ([]string, error) {
 		switch tok := token.(type) {
 		case xml.EndElement:
 			if tok.Name.Local == "PARA" || tok.Name.Local == "POP" {
-				lines = append(lines, line)
-				line = ""
+				lines = append(lines, sb.String())
+				sb.Reset()
 			}
 		case xml.CharData:
-			line += string(tok)
+			sb.WriteString(string(tok))
 		default:
 			continue
 		}

--- a/configs/configs_mapped/freelancer_mapped/infocard_mapped/infocard/xml.go
+++ b/configs/configs_mapped/freelancer_mapped/infocard_mapped/infocard/xml.go
@@ -1,34 +1,42 @@
 package infocard
 
 import (
+	"bytes"
 	"encoding/xml"
-	"strings"
+	"io"
 )
-
-type RDL struct {
-	XMLName xml.Name `xml:"RDL"`
-	TEXT    []string `xml:"TEXT"`
-}
 
 func (i *Infocard) XmlToText() ([]string, error) {
 	return XmlToText(i.content)
 }
 
-func XmlToText(xml_stuff string) ([]string, error) {
-	var structy RDL
+func XmlToText(raw string) ([]string, error) {
+	decoder := xml.NewDecoder(bytes.NewBufferString(raw))
 
-	prepared := strings.ReplaceAll(string(xml_stuff), `<?xml version="1.0" encoding="UTF-16"?>`, "")
+	lines := make([]string, 0)
+	line := ""
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return nil, err
+			}
+		}
 
-	err := xml.Unmarshal([]byte(prepared), &structy)
-
-	if _, ok := err.(*xml.SyntaxError); ok {
-		replaced := strings.ReplaceAll(prepared, "&", "")
-		err = xml.Unmarshal([]byte(replaced), &structy)
+		switch tok := token.(type) {
+		case xml.EndElement:
+			if tok.Name.Local == "PARA" || tok.Name.Local == "POP" {
+				lines = append(lines, line)
+				line = ""
+			}
+		case xml.CharData:
+			line += string(tok)
+		default:
+			continue
+		}
 	}
 
-	// logus.Log.CheckError(err, "unable converting xml to text", typelog.String("xml_stuff", string(xml_stuff)))
-	if err != nil {
-		return nil, err
-	}
-	return structy.TEXT, nil
+	return lines, nil
 }

--- a/configs/configs_mapped/freelancer_mapped/infocard_mapped/infocard/xml.go
+++ b/configs/configs_mapped/freelancer_mapped/infocard_mapped/infocard/xml.go
@@ -15,7 +15,7 @@ func XmlToText(raw string) ([]string, error) {
 	prepared := strings.ReplaceAll(string(raw), `<?xml version="1.0" encoding="UTF-16"?>`, "")
 	decoder := xml.NewDecoder(bytes.NewBufferString(prepared))
 
-	lines := make([]string, 0)
+	lines := make([]string, 0, 10)
 	var sb strings.Builder
 	for {
 		token, err := decoder.Token()


### PR DESCRIPTION
### Motivation

Every XML `TEXT` element is processed as a separate line, which causes incorrect display for formatted text for many FLHD strings.

![image](https://github.com/darklab8/fl-configs/assets/4773889/afd73646-6b06-4be0-9ba5-6698513dc5e6)

### Solution

Use `XmlDecoder` instead of struct unmarshalling to imperatively process tags and create lines based on PARA or POP occurrences.

![image](https://github.com/darklab8/fl-configs/assets/4773889/6d13e2c4-d8ad-47a2-a5d8-a2544475414a)
